### PR TITLE
Add support for custom delimiters and template contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved.
 
 ## How do templates work?
 
+To get started, use the
+[templates.NewResolver](https://pkg.go.dev/github.com/open-cluster-management/go-template-utils/pkg/templates#NewResolver)
+function along with a
+[templates.Config](https://pkg.go.dev/github.com/open-cluster-management/go-template-utils/pkg/templates#Config)
+instance.
+
+See the
+[ResolveTemplate example](https://pkg.go.dev/github.com/open-cluster-management/go-template-utils/pkg/templates#example_TemplateResolver_ResolveTemplate)
+for an example of how to use this library.
+
 Under the hood, `go-template-utils` wraps the
 [text/template](https://pkg.go.dev/text/template) package. This means that as
 long as the input to

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -175,6 +175,10 @@ issues:
       linters:
         - errcheck
         - maligned
+    # False positive: https://github.com/kunwardeep/paralleltest/issues/8.
+    - linters:
+      - paralleltest
+      text: "does not use range value in test Run"
 
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all

--- a/pkg/templates/clusterconfig_funcs.go
+++ b/pkg/templates/clusterconfig_funcs.go
@@ -12,8 +12,8 @@ import (
 )
 
 // retrieve the Spec value for the given clusterclaim.
-func fromClusterClaim(claimname string) (string, error) {
-	dclient, dclientErr := getDynamicClient(
+func (t *TemplateResolver) fromClusterClaim(claimname string) (string, error) {
+	dclient, dclientErr := t.getDynamicClient(
 		"cluster.open-cluster-management.io/v1alpha1",
 		"ClusterClaim",
 		"",

--- a/pkg/templates/k8sresource_funcs.go
+++ b/pkg/templates/k8sresource_funcs.go
@@ -13,10 +13,10 @@ import (
 )
 
 // retrieves the value of the key in the given Secret, namespace.
-func fromSecret(namespace string, secretname string, key string) (string, error) {
+func (t *TemplateResolver) fromSecret(namespace string, secretname string, key string) (string, error) {
 	glog.V(glogDefLvl).Infof("fromSecret for namespace: %v, secretname: %v, key:%v", namespace, secretname, key)
 
-	secretsClient := (*kubeClient).CoreV1().Secrets(namespace)
+	secretsClient := (*t.kubeClient).CoreV1().Secrets(namespace)
 	secret, getErr := secretsClient.Get(context.TODO(), secretname, metav1.GetOptions{})
 
 	if getErr != nil {
@@ -39,10 +39,10 @@ func fromSecret(namespace string, secretname string, key string) (string, error)
 }
 
 // retrieves value for the key in the given Configmap, namespace.
-func fromConfigMap(namespace string, cmapname string, key string) (string, error) {
+func (t *TemplateResolver) fromConfigMap(namespace string, cmapname string, key string) (string, error) {
 	glog.V(glogDefLvl).Infof("fromConfigMap for namespace: %v, configmap name: %v, key:%v", namespace, cmapname, key)
 
-	configmapsClient := (*kubeClient).CoreV1().ConfigMaps(namespace)
+	configmapsClient := (*t.kubeClient).CoreV1().ConfigMaps(namespace)
 	configmap, getErr := configmapsClient.Get(context.TODO(), cmapname, metav1.GetOptions{})
 
 	if getErr != nil {

--- a/pkg/templates/k8sresource_funcs_test.go
+++ b/pkg/templates/k8sresource_funcs_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"k8s.io/client-go/rest"
 )
 
 func TestFromSecret(t *testing.T) {
@@ -30,8 +32,9 @@ func TestFromSecret(t *testing.T) {
 		{"testns", "testsecret", "blah", "", nil}, // error : nonexistant key
 	}
 
+	resolver := getTemplateResolver(Config{KubeConfig: &rest.Config{}})
 	for _, test := range testcases {
-		val, err := fromSecret(test.inputNs, test.inputCMname, test.inputKey)
+		val, err := resolver.fromSecret(test.inputNs, test.inputCMname, test.inputKey)
 
 		if err != nil {
 			if test.expectedErr == nil {
@@ -61,8 +64,10 @@ func TestFromConfigMap(t *testing.T) {
 		{"testns", "testconfigmap", "idontexist", "", nil},
 	}
 
+	resolver := getTemplateResolver(Config{KubeConfig: &rest.Config{}})
+
 	for _, test := range testcases {
-		val, err := fromConfigMap(test.inputNs, test.inputCMname, test.inputKey)
+		val, err := resolver.fromConfigMap(test.inputNs, test.inputCMname, test.inputKey)
 
 		if err != nil {
 			if test.expectedErr == nil {


### PR DESCRIPTION
The custom delimiter support will allow distinguishing between multiple kinds of templates in
the same YAML file (e.g. `{{` vs `{{hub`).

Additionally, the template context support will allow the user to use the context of the policy being resolved in their templates. For example, they may use `.ClusterName` as a variable in their templates to reference the target cluster name that this template is being generated for.