### PR TITLE
Modify ResolveTemplate to accept a JSON string

### DIFF
--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -207,7 +207,7 @@ func TestResolveTemplate(t *testing.T) {
 	for _, test := range testcases {
 		tmplStr, _ := yaml.YAMLToJSON([]byte(test.inputTmpl))
 		resolver := getTemplateResolver(test.config)
-		val, err := resolver.ResolveTemplate(string(tmplStr), test.ctx)
+		val, err := resolver.ResolveTemplate(tmplStr, test.ctx)
 
 		if err != nil {
 			if test.expectedErr == nil {
@@ -217,7 +217,7 @@ func TestResolveTemplate(t *testing.T) {
 				t.Fatalf("expected err: %s got err: %s", test.expectedErr, err)
 			}
 		} else {
-			val, _ := yaml.JSONToYAML([]byte(val))
+			val, _ := yaml.JSONToYAML(val)
 			valStr := strings.TrimSuffix(string(val), "\n")
 			if valStr != test.expectedResult {
 				t.Fatalf("expected : %s , got : %s", test.expectedResult, val)
@@ -243,7 +243,7 @@ func TestHasTemplate(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		val := HasTemplate(test.input, test.startDelim)
+		val := HasTemplate([]byte(test.input), test.startDelim)
 		if val != test.result {
 			t.Fatalf("expected : %v , got : %v", test.result, val)
 		}
@@ -401,14 +401,14 @@ spec:
 	}
 
 	templateContext := struct{ ClusterName string }{ClusterName: "cluster0001"}
-	policyResolvedJSON, err := resolver.ResolveTemplate(string(policyJSON), templateContext)
+	policyResolvedJSON, err := resolver.ResolveTemplate(policyJSON, templateContext)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to process the policy YAML: %v\n", err)
 		panic(err)
 	}
 
 	var policyResolved interface{}
-	err = yaml.Unmarshal([]byte(policyResolvedJSON), &policyResolved)
+	err = yaml.Unmarshal(policyResolvedJSON, &policyResolved)
 
 	objTmpls := policyResolved.(map[string]interface{})["spec"].(map[string]interface{})["object-templates"]
 	objDef := objTmpls.([]interface{})[0].(map[string]interface{})["objectDefinition"]

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -365,6 +365,7 @@ metadata:
   name: demo-sampleapp-config
   namespace: sampleapp
 spec:
+  remediationAction: enforce
   namespaceSelector:
     exclude:
     - kube-*
@@ -381,7 +382,6 @@ spec:
       data:
         message: '{{ "VGVtcGxhdGVzIHJvY2sh" | base64dec }}'
         b64-cluster-name: '{{ .ClusterName | base64enc }}'
-    remediationAction: enforce
     severity: high
 `
 


### PR DESCRIPTION
This makes the API more intuitive as you don't need to unmarshal
the JSON first, which is the most common format in hand when using this
library.

Additionally, it makes the API consistent since HasTemplate and
ResolveTemplate now both accept the same type as input.