### PR TITLE
Disable fromClusterClaim when namespace restrictions are set

### DIFF
--- a/pkg/templates/clusterconfig_funcs.go
+++ b/pkg/templates/clusterconfig_funcs.go
@@ -5,6 +5,7 @@ package templates
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -13,11 +14,19 @@ import (
 
 // retrieve the Spec value for the given clusterclaim.
 func (t *TemplateResolver) fromClusterClaim(claimname string) (string, error) {
+	if t.lookupNamespace != "" {
+		msg := fmt.Sprintf(
+			"fromClusterClaim is not supported because lookups are restricted to the %s namespace",
+			t.lookupNamespace,
+		)
+
+		return "", errors.New(msg)
+	}
+
 	dclient, dclientErr := t.getDynamicClient(
 		"cluster.open-cluster-management.io/v1alpha1",
 		"ClusterClaim",
-		// If set, this restricts to a particular namespace
-		t.lookupNamespace,
+		"",
 	)
 	if dclientErr != nil {
 		err := fmt.Errorf("failed to get the cluster claim %s: %w", claimname, dclientErr)

--- a/pkg/templates/clusterconfig_funcs_test.go
+++ b/pkg/templates/clusterconfig_funcs_test.go
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package templates
+
+import (
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestFromClusterClaimNsError(t *testing.T) {
+	t.Parallel()
+	var kubeClient kubernetes.Interface = fake.NewSimpleClientset()
+	kubeConfig := &rest.Config{}
+	config := Config{LookupNamespace: "my-policies"}
+	resolver, _ := NewResolver(&kubeClient, kubeConfig, config)
+
+	_, err := resolver.fromClusterClaim("clusterID")
+
+	if err == nil {
+		t.Fatal("Expecting an error but did not get one")
+	}
+
+	expectedMsg := "fromClusterClaim is not supported because lookups are restricted to the my-policies namespace"
+	if err.Error() != expectedMsg {
+		t.Fatalf(`Expected the error "%s", but got "%s"`, expectedMsg, err.Error())
+	}
+}


### PR DESCRIPTION
In commit 612affb, an attempt was made to restrict fromClusterClaim to a
specific namespace when the namespace is restricted (LookupNamespace).
The issue is that ClusterClaim is a cluster resource and not a namespace
resource so this approach did not work.

This commit makes it so that fromClusterClaim raises an error when the
namespace is restricted (LookupNamespace).