### PR TITLE
Add the AdditionalIndentation configuration option

### DIFF
--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -203,6 +203,13 @@ func TestResolveTemplate(t *testing.T) {
 			nil,
 		},
 		{
+			"spec:\n  config1: |\n    {{hub " + `"hello\nworld\n"` + " | indent 4 hub}}\n",
+			Config{AdditionalIndentation: 4, StartDelim: "{{hub", StopDelim: "hub}}"},
+			struct{}{},
+			"spec:\n    config1: |\n        hello\n        world",
+			nil,
+		},
+		{
 			"spec:\n  config1: |\n    {{ " + `"hello\nworld\n"` + " | autoindent }}\n",
 			Config{},
 			struct{}{},


### PR DESCRIPTION
AdditionalIndentation sets the number of additional spaces to be added
to the input number to the indent method. This is useful in situations
when the indentation should be relative to a logical starting point in
a YAML file.