### PR TITLE
Refactor the TemplateResolver type to not duplicate config fields

### DIFF
--- a/pkg/templates/clusterconfig_funcs.go
+++ b/pkg/templates/clusterconfig_funcs.go
@@ -14,10 +14,10 @@ import (
 
 // retrieve the Spec value for the given clusterclaim.
 func (t *TemplateResolver) fromClusterClaim(claimname string) (string, error) {
-	if t.lookupNamespace != "" {
+	if t.config.LookupNamespace != "" {
 		msg := fmt.Sprintf(
 			"fromClusterClaim is not supported because lookups are restricted to the %s namespace",
-			t.lookupNamespace,
+			t.config.LookupNamespace,
 		)
 
 		return "", errors.New(msg)

--- a/pkg/templates/generic_lookup_func.go
+++ b/pkg/templates/generic_lookup_func.go
@@ -22,15 +22,19 @@ import (
 // configuration is, then the namespace of lookupNamespace is returned for convenience.
 func (t *TemplateResolver) getNamespace(funcName, namespace string) (string, error) {
 	// When lookupNamespace is an empty string, there are no namespace restrictions.
-	if t.lookupNamespace != "" {
+	if t.config.LookupNamespace != "" {
 		// If lookupNamespace is set but namespace is an empty string, then default
 		// to lookupNamespace for convenience
 		if namespace == "" {
-			return t.lookupNamespace, nil
+			return t.config.LookupNamespace, nil
 		}
 
-		if t.lookupNamespace != namespace {
-			msg := fmt.Sprintf("the namespace argument passed to %s is restricted to %s", funcName, t.lookupNamespace)
+		if t.config.LookupNamespace != namespace {
+			msg := fmt.Sprintf(
+				"the namespace argument passed to %s is restricted to %s",
+				funcName,
+				t.config.LookupNamespace,
+			)
 			glog.Error(msg)
 
 			return "", errors.New(msg)
@@ -137,7 +141,7 @@ func (t *TemplateResolver) findAPIResource(gvk schema.GroupVersionKind) (metav1.
 
 	// check if an apiresource list is available already (i.e provided as input to templates)
 	// if not available use api discovery client to get api resource list
-	apiResList := t.kubeAPIResourceList
+	apiResList := t.config.KubeAPIResourceList
 	if apiResList == nil {
 		var ddErr error
 		apiResList, ddErr = t.discoverAPIResources()

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -74,8 +74,12 @@ func TestNewResolver(t *testing.T) {
 		t.Fatalf("No error was expected: %v", err)
 	}
 
-	if resolver.startDelim != "{{" || resolver.stopDelim != "}}" {
-		t.Fatalf("Expected delimiters: {{ and }}  got: %s and %s", resolver.startDelim, resolver.stopDelim)
+	if resolver.config.StartDelim != "{{" || resolver.config.StopDelim != "}}" {
+		t.Fatalf(
+			"Expected delimiters: {{ and }}  got: %s and %s",
+			resolver.config.StartDelim,
+			resolver.config.StopDelim,
+		)
 	}
 }
 


### PR DESCRIPTION
Instead of duplicating the configuration fields in TemplateResolver, it now holds on to the Config object itself and refers to that.