### PR TITLE
Make the autoindent regex stricter

### DIFF
--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -252,7 +252,7 @@ func (t *TemplateResolver) processForAutoIndent(str string) string {
 	// This is not a very strict regex as occasionally, a user will make a mistake such as
 	// `config: '{{ "hello\nworld" | autoindent }}'`. In that event, `autoindent` will change to
 	// `indent 1`, but `indent` properly handles this.
-	re := regexp.MustCompile(`( *)(?:.*` + d1 + `.*\| *autoindent *` + d2 + `)`)
+	re := regexp.MustCompile(`( *)(?:'|")?(` + d1 + `.*\| *autoindent *` + d2 + `)`)
 	glog.V(glogDefLvl).Infof("\n Pattern: %v\n", re.String())
 
 	submatches := re.FindAllStringSubmatch(str, -1)
@@ -261,7 +261,7 @@ func (t *TemplateResolver) processForAutoIndent(str string) string {
 	processed := str
 	for _, submatch := range submatches {
 		numSpaces := len(submatch[1]) - int(t.config.AdditionalIndentation)
-		matchStr := submatch[0]
+		matchStr := submatch[2]
 		newMatchStr := strings.Replace(matchStr, "autoindent", fmt.Sprintf("indent %d", numSpaces), 1)
 		processed = strings.Replace(processed, matchStr, newMatchStr, 1)
 	}

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -235,6 +235,13 @@ func TestResolveTemplate(t *testing.T) {
 			nil,
 		},
 		{
+			"spec:\n  autoindent-test: '{{ " + `"hello\nworld\nagain\n"` + " | autoindent }}'\n",
+			Config{AdditionalIndentation: 4},
+			struct{}{},
+			"spec:\n    autoindent-test: hello world again",
+			nil,
+		},
+		{
 			`test: '{{ printf "hello %s" "world" }}'`,
 			Config{},
 			123,


### PR DESCRIPTION
This resolves the edge case where a user has autoindent in the key of
a map. For example:
```yaml
data:
  autoindent-test: '{{ "hello\nworld" | autoindent }}'
```